### PR TITLE
Ensure pod install does not fail because of missing homepage

### DIFF
--- a/ios/RNSuperpowered.podspec
+++ b/ios/RNSuperpowered.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNSuperpowered
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/x86kernel/react-native-superpowered"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "x86kernel@gmail.com" }


### PR DESCRIPTION
When adding this to my project I received the following error. 

```
➜ pod install
Detected React Native module pod for RNSuperpowered
Analyzing dependencies
Fetching podspec for `Interactable` from `../node_modules/react-native-interactable`
Fetching podspec for `RNGestureHandler` from `../node_modules/react-native-gesture-handler`
Fetching podspec for `RNScreens` from `../node_modules/react-native-screens`
Fetching podspec for `RNSuperpowered` from `../node_modules/react-native-superpowered/ios`
[!] The `RNSuperpowered` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```

This PR allows for `pod install` to work. 